### PR TITLE
fix(env): 更新后端服务地址

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,2 @@
 VITE_APP_API_BASE_URL=http://10.16.62.100:12345
-VITE_APP_PROD_API_BASE_URL=http://backend.smartclass.ubanillx.cn
+VITE_APP_PROD_API_BASE_URL=http://backend.smartclass.ubanillx.cn:8081

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN npm ci
 COPY . .
 
 # 创建生产环境变量文件（如果在容器构建期间需要覆盖环境变量）
-RUN echo "VITE_APP_API_BASE_URL=${API_BASE_URL:-http://backend.smartclass.ubanillx.cn/api}" > .env.production
+RUN echo "VITE_APP_API_BASE_URL=${API_BASE_URL:-http://backend.smartclass.ubanillx.cn:8081/api}" > .env.production
 
 # 构建应用
 RUN npm run build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     ports:
       - '80:80'
     environment:
-      - API_BASE_URL=http://backend.smartclass.ubanillx.cn/api
+      - API_BASE_URL=http://backend.smartclass.ubanillx.cn:8081/api
     restart: always
     networks:
       - smartclass-network

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -9,7 +9,7 @@ import axios, {
 const isDevelopment = import.meta.env.MODE === 'development';
 const API_BASE = isDevelopment
   ? '/' // 使用相对路径，会被代理到后端服务器
-  : 'http://backend.smartclass.ubanillx.cn:8081/';
+  : 'http://backend.smartclass.ubanillx.cn:8081';
 
 const apiClient: AxiosInstance = axios.create({
   baseURL: API_BASE,


### PR DESCRIPTION
- 在 .env 文件中更新 VITE_APP_PROD_API_BASE_URL为 http://backend.smartclass.ubanillx.cn:8081
- 在 docker-compose.yml 中更新 API_BASE_URL 为 http://backend.smartclass.ubanillx.cn:8081/api- 在 Dockerfile 中更新 .env.production 文件中的 VITE_APP_API_BASE_URL 为 http://backend.smartclass.ubanillx.cn:8081/api
- 在 src/api/index.ts 中更新生产环境下的 API_BASE 为 http://backend.smartclass.ubanillx.cn:8081