### PR TITLE
build: 更新 Node.js 版本并调整 API 路由前缀

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # 构建阶段: 使用Node.js环境
-FROM node:16-alpine as build-stage
+FROM node:18-alpine as build-stage
 
 # 设置工作目录
 WORKDIR /app

--- a/rsbuild.config.ts
+++ b/rsbuild.config.ts
@@ -19,6 +19,7 @@ export default defineConfig({
         target: 'http://10.16.62.100:12345',
         changeOrigin: true,
         secure: false,
+        pathRewrite: { '^/api': '' },
       },
     },
   },

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -8,8 +8,8 @@ import axios, {
 // 根据当前环境判断使用哪个API基础URL
 const isDevelopment = import.meta.env.MODE === 'development';
 const API_BASE = isDevelopment
-  ? '/' // 使用相对路径，会被代理到后端服务器
-  : import.meta.env.VITE_APP_PROD_API_BASE_URL || 'http://backend.smartclass.ubanillx.cn:8081';
+  ? '/api' // 使用/api前缀，将被代理到后端服务器
+  : (import.meta.env.VITE_APP_PROD_API_BASE_URL || 'http://backend.smartclass.ubanillx.cn:8081');
 
 // 只在开发环境中输出调试信息
 if (isDevelopment) {

--- a/src/services/core/OpenAPI.ts
+++ b/src/services/core/OpenAPI.ts
@@ -21,9 +21,10 @@ export type OpenAPIConfig = {
 
 // 根据当前环境确定API基础URL
 const isDevelopment = import.meta.env.MODE === 'development';
+// 在开发环境中使用/api作为前缀，在生产环境中不使用前缀，因为OpenAPI生成的服务路径已经包含/api前缀
 const API_BASE = isDevelopment
-  ? '/' // 开发环境使用相对路径，会被代理到后端服务器
-  : import.meta.env.VITE_APP_PROD_API_BASE_URL || 'http://backend.smartclass.ubanillx.cn:8081';
+  ? '/api' // 开发环境使用/api前缀，会被代理到后端服务器
+  : (import.meta.env.VITE_APP_PROD_API_BASE_URL || 'http://backend.smartclass.ubanillx.cn:8081');
 
 // 只在开发环境中输出调试信息
 if (isDevelopment) {


### PR DESCRIPTION
- 将 Node.js版本从 16 升级到 18
- 在开发环境中为 API 路径添加 /api 前缀- 更新 OpenAPI 服务路径以适应新的前缀
- 在 rsbuild 配置中添加路径重写规则以支持新的 API前缀