### PR TITLE
docs(README): 添加管理端仓库链接

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 ## 相关项目
 
 - **后端仓库**: [smartclass-backend](https://github.com/Ubanillx/smartclass-backend) - 基于Spring Boot的后端服务
+- **管理端仓库** [smartclass-man-backend](https://github.com/Ubanillx/smartclass-manage-frontend)
 
 ## 功能特点
 


### PR DESCRIPTION
在 README.md 文件中的"相关项目"部分添加了管理端仓库的链接，便于用户访问和了解管理端的前端项目。